### PR TITLE
Fix for issue where np.int is a deprecated alias for the built-in int in newer versions of numpy

### DIFF
--- a/idr/idr.py
+++ b/idr/idr.py
@@ -296,8 +296,8 @@ def build_rank_vectors(merged_peaks):
     rank1 = numpy.lexsort((numpy.random.random(len(s1)), s1)).argsort()
     rank2 = numpy.lexsort((numpy.random.random(len(s2)), s2)).argsort()
     
-    return ( numpy.array(rank1, dtype=numpy.int), 
-             numpy.array(rank2, dtype=numpy.int) )
+    return ( numpy.array(rank1, dtype=numpy.int32), 
+             numpy.array(rank2, dtype=numpy.int32) )
 
 def build_idr_output_line_with_bed6(
         m_pk, IDR, localIDR, output_file_type, signal_type, 


### PR DESCRIPTION
… 